### PR TITLE
Fix ToC sidebar layout

### DIFF
--- a/TASK_HISTORY.md
+++ b/TASK_HISTORY.md
@@ -16,3 +16,11 @@ Catatan ringkas perubahan yang dilakukan oleh Codex.
 - Used `rehype-slug` and `rehype-autolink-headings` in `astro.config.mjs` to support heading anchors
 - Smooth scrolling enabled on anchor click
 - ToC hidden on mobile using `hidden lg:block`
+
+## [2025-06-08] Fix Table of Contents layout
+- Updated `src/layouts/BlogPost.astro` with a responsive grid container and named
+  slots for content and ToC
+- `max-w-6xl mx-auto px-4` keeps the layout centered without overflow and shows a
+  250px sidebar on large screens
+- Adjusted `src/pages/blog/[...slug].astro` to use the new slots
+- ToC remains hidden on mobile and no longer causes horizontal scrolling

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -57,30 +57,33 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 
 	<body>
 		<Header />
-		<main>
-			<article>
-				<div class="hero-image">
-					{heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
-				</div>
-				<div class="prose">
-					<div class="title">
-						<div class="date">
-							<FormattedDate date={pubDate} />
-							{
-								updatedDate && (
-									<div class="last-updated-on">
-										Last updated on <FormattedDate date={updatedDate} />
-									</div>
-								)
-							}
-						</div>
-						<h1>{title}</h1>
-						<hr />
-					</div>
-					<slot />
-				</div>
-			</article>
-		</main>
+                <main>
+                        <article class="mx-auto max-w-6xl px-4 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_250px] lg:gap-8">
+                                <div>
+                                        <div class="hero-image">
+                                                {heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
+                                        </div>
+                                        <div class="prose">
+                                                <div class="title">
+                                                        <div class="date">
+                                                                <FormattedDate date={pubDate} />
+                                                                {
+                                                                        updatedDate && (
+                                                                                <div class="last-updated-on">
+                                                                                        Last updated on <FormattedDate date={updatedDate} />
+                                                                                </div>
+                                                                        )
+                                                                }
+                                                        </div>
+                                                        <h1>{title}</h1>
+                                                        <hr />
+                                                </div>
+                                                <slot name="content" />
+                                        </div>
+                                </div>
+                                <slot name="toc" />
+                        </article>
+                </main>
 		<Footer />
 	</body>
 </html>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,10 +19,6 @@ const { Content, headings } = await render(post);
 ---
 
 <BlogPost {...post.data}>
-        <div class="lg:flex lg:gap-8">
-                <div class="flex-1">
-                        <Content />
-                </div>
-                <TableOfContents {headings} />
-        </div>
+        <Content slot="content" />
+        <TableOfContents slot="toc" {headings} />
 </BlogPost>


### PR DESCRIPTION
## Summary
- adjust blog layout to use a responsive grid with content + ToC slots
- use the new slots in the `[...slug].astro` page
- document layout changes in `TASK_HISTORY.md`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68458266eea483248eda0a13ff515028