### PR TITLE
Align ToC with content header

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -18,7 +18,7 @@ for (const h of filtered) {
 }
 ---
 {grouped.length > 0 && (
-  <aside class="hidden lg:block w-60 shrink-0 sticky top-24 text-sm leading-6">
+  <aside class="hidden lg:block w-60 shrink-0 sticky top-24 mt-20 text-sm leading-6 p-4 border border-gray-300 rounded-xl shadow-md bg-gray-50 dark:bg-gray-800">
     <ul class="space-y-2">
       {grouped.map(section => (
         <li>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -58,11 +58,11 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 	<body>
 		<Header />
                 <main>
-                        <article class="mx-auto max-w-6xl px-4 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_250px] lg:gap-8">
-                                <div>
-                                        <div class="hero-image">
-                                                {heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
-                                        </div>
+                        <article class="mx-auto max-w-6xl px-4">
+                                <div class="hero-image">
+                                        {heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
+                                </div>
+                                <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_250px] lg:gap-8">
                                         <div class="prose">
                                                 <div class="title">
                                                         <div class="date">
@@ -80,8 +80,8 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
                                                 </div>
                                                 <slot name="content" />
                                         </div>
+                                        <slot name="toc" />
                                 </div>
-                                <slot name="toc" />
                         </article>
                 </main>
 		<Footer />


### PR DESCRIPTION
## Summary
- move hero image outside grid so ToC starts next to blog body
- wrap Table of Contents in a styled box

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68458c6d94c4832498c5636166e4c57f