### PR TITLE
Refine ToC alignment and styling

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -18,7 +18,7 @@ for (const h of filtered) {
 }
 ---
 {grouped.length > 0 && (
-  <aside class="hidden lg:block w-60 shrink-0 sticky top-24 mt-20 text-sm leading-6 p-4 border border-gray-300 rounded-xl shadow-md bg-gray-50 dark:bg-gray-800">
+  <aside class="hidden lg:block w-60 shrink-0 sticky top-20 mt-20 text-sm leading-6 p-4 border border-gray-300 rounded-xl shadow-md bg-white dark:bg-gray-900">
     <ul class="space-y-2">
       {grouped.map(section => (
         <li>


### PR DESCRIPTION
## Summary
- align sticky offset so ToC sits level with article text
- soften ToC background colors for light and dark themes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68458fb963408324ba74db9d5ae903f3